### PR TITLE
Fix `Extension.register()` API and related files / 모듈 등록 방식 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ certs/
 savedfiles/
 settings.ini
 .env
+*.pyc

--- a/base.py
+++ b/base.py
@@ -3,16 +3,17 @@
 # base.py
 # base (common) file
 #
-# Caterpillar Proxy - The simple and parasitic web proxy SPAM spam filter
+# Caterpillar Proxy - The simple web debugging proxy (formerly, php-httpproxy)
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-05-20
-# Updated at: 2024-05-21
+# Updated at: 2024-07-06
 #
 
 import hashlib
 import json
 import re
+import importlib
 
 client_encoding = 'utf-8'
 
@@ -71,8 +72,13 @@ class Extension():
         cls.buffer_size = _buffer_size
 
     @classmethod
-    def register(cls, f):
-        cls.extensions.append(f)
+    def register(cls, module_path, class_name):
+        try:
+            module = importlib.import_module(module_path)
+            _class = getattr(module, class_name)
+            cls.extensions.append(_class())
+        except (ImportError, AttributeError) as e:
+            raise ImportError(class_name + " in " + module_path)
 
     @classmethod
     def get_filters(cls):

--- a/plugins/container.py
+++ b/plugins/container.py
@@ -7,12 +7,12 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-03-04
-# Updated at: 2024-03-13
+# Updated at: 2024-07-06
 #
 
 import docker
 
-from server import Extension
+from base import Extension
 
 class Container(Extension):
     def __init__(self):

--- a/plugins/fediverse.py
+++ b/plugins/fediverse.py
@@ -8,7 +8,7 @@
 # https://github.com/gnh1201/caterpillar
 #
 # Created in: 2022-10-06
-# Updated in: 2024-06-05
+# Updated in: 2024-07-06
 #
 
 import io
@@ -19,7 +19,7 @@ import os.path
 from decouple import config
 from PIL import Image
 
-from server import Extension
+from base import Extension
 
 try:
     client_encoding = config('CLIENT_ENCODING', default='utf-8')

--- a/plugins/wayback.py
+++ b/plugins/wayback.py
@@ -7,12 +7,13 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-03-13
-# Updated at: 2024-03-13
+# Updated at: 2024-07-06
 #
 
 import requests
+from decouple import config
 
-from server import Extension
+from base import Extension
 
 try:
     client_encoding = config('CLIENT_ENCODING')

--- a/server.py
+++ b/server.py
@@ -23,7 +23,6 @@ import time
 import hashlib
 import traceback
 import textwrap
-import importlib
 from datetime import datetime
 from platform import python_version
 
@@ -499,9 +498,10 @@ def start():    #Main Program
 
 if __name__== "__main__":
     # load extensions
-    #Extension.register(importlib.import_module("plugins.fediverse").Fediverse())
-    #Extension.register(importlib.import_module("plugins.container").Container())
-    #Extension.register(importlib.import_module("plugins.wayback").Wayback())
-    
-    # start Caterpillar
+    #Extension.register("plugins.fediverse", "Fediverse")
+    #Extension.register("plugins.container", "Container")
+    Extension.register("plugins.wayback", "Wayback")
+    #Extension.register("plugins.bio", "PyBio")
+
+   # start Caterpillar
     start()

--- a/web.py
+++ b/web.py
@@ -7,7 +7,7 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-05-20
-# Updated at: 2024-05-20
+# Updated at: 2024-07-06
 #
 
 from flask import Flask, request, redirect, url_for, render_template
@@ -94,6 +94,6 @@ if __name__ == "__main__":
     Extension.set_protocol('http')
 
     # load extensions
-    #Extension.register(importlib.import_module("plugins.yourownplugin").YourOwnPlugin())
+    #Extension.register("plugins.YOUR_OWN_MODULE_NAME", "YOUR_OWN_CLASS_NAME");
 
     app.run(debug=True, host='0.0.0.0', port=listening_port)


### PR DESCRIPTION
## 요약
* 플러그인 내 모든 Extension 관련 import 선언 변경 (base.py로 분리하기 전 파일이라 변경이 미처 안되어 있었음.)
  * 기존:  `from server import Extension` 
  * 변경: `from base import Extension`
* `Extension.register()` API 호출 방식 변경
  * 기존: `Extension.register(importlib.import_module("plugins.wayback").Wayback())`
  * 변경: `Extension.register("plugins.wayback", "Wayback")`
* 그 외 mistypo 수정 (빠진 import 등)