### PR TITLE
Change the `Extension.register()` process / 확장 등록 프로세스 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CERT_KEY=cert.key
 CERT_DIR=certs/
 OPENSSL_BINPATH=openssl
 CLIENT_ENCODING=utf-8
+LOADED_EXTENSIONS=wayback
 ```
 
 - (Optional) Create a certificate for SSL decryption

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CERT_KEY=cert.key
 CERT_DIR=certs/
 OPENSSL_BINPATH=openssl
 CLIENT_ENCODING=utf-8
-USE_EXTENSIONS=Wayback,PyBio
+USE_EXTENSIONS=wayback.Wayback,bio.PyBio
 ```
 
 - (Optional) Create a certificate for SSL decryption

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CERT_KEY=cert.key
 CERT_DIR=certs/
 OPENSSL_BINPATH=openssl
 CLIENT_ENCODING=utf-8
-LOADED_EXTENSIONS=wayback
+ENABLED_EXTENSIONS=wayback
 ```
 
 - (Optional) Create a certificate for SSL decryption

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CERT_KEY=cert.key
 CERT_DIR=certs/
 OPENSSL_BINPATH=openssl
 CLIENT_ENCODING=utf-8
-ENABLED_EXTENSIONS=wayback
+USE_EXTENSIONS=Wayback,PyBio
 ```
 
 - (Optional) Create a certificate for SSL decryption

--- a/base.py
+++ b/base.py
@@ -73,9 +73,8 @@ class Extension():
 
     @classmethod
     def register(cls, s)
-        module_name = s.split('.')[0]
+        module_name, class_name = s.trim().split('.')[0:2]
         module_path = 'plugins.' + module_name
-        class_name = s.split('.')[-1]
 
         try:
             module = importlib.import_module(module_path)

--- a/base.py
+++ b/base.py
@@ -72,8 +72,8 @@ class Extension():
         cls.buffer_size = _buffer_size
 
     @classmethod
-    def register(cls, s)
-        module_name, class_name = s.trim().split('.')[0:2]
+    def register(cls, s):
+        module_name, class_name = s.strip().split('.')[0:2]
         module_path = 'plugins.' + module_name
 
         try:

--- a/base.py
+++ b/base.py
@@ -7,7 +7,7 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-05-20
-# Updated at: 2024-07-06
+# Updated at: 2024-07-09
 #
 
 import hashlib
@@ -72,13 +72,17 @@ class Extension():
         cls.buffer_size = _buffer_size
 
     @classmethod
-    def register(cls, module_path, class_name):
+    def register(cls, s)
+        module_name = s.split('.')[0]
+        module_path = 'plugins.' + module_name
+        class_name = s.split('.')[-1]
+
         try:
             module = importlib.import_module(module_path)
             _class = getattr(module, class_name)
             cls.extensions.append(_class())
         except (ImportError, AttributeError) as e:
-            raise ImportError(class_name + " in " + module_path)
+            raise ImportError(class_name + " in the extension " + module_name)
 
     @classmethod
     def get_filters(cls):

--- a/server.py
+++ b/server.py
@@ -47,6 +47,7 @@ try:
     client_encoding = config('CLIENT_ENCODING', default='utf-8')
     local_domain = config('LOCAL_DOMAIN', default='')
     proxy_pass = config('PROXY_PASS', default='')
+    use_extensions = config('USE_EXTENSIONS', default='')
 except KeyboardInterrupt:
     print("\n[*] User has requested an interrupt")
     print("[*] Application Exiting.....")
@@ -498,10 +499,7 @@ def start():    #Main Program
 
 if __name__== "__main__":
     # load extensions
-    #Extension.register("plugins.fediverse", "Fediverse")
-    #Extension.register("plugins.container", "Container")
-    Extension.register("plugins.wayback", "Wayback")
-    #Extension.register("plugins.bio", "PyBio")
+    map(Extension.register, use_extension.split(',')))
 
-   # start Caterpillar
+    # start Caterpillar
     start()

--- a/server.py
+++ b/server.py
@@ -499,7 +499,8 @@ def start():    #Main Program
 
 if __name__== "__main__":
     # load extensions
-    map(Extension.register, use_extension.split(','))
+    for s in use_extensions.split(','):
+        Extension.register(s)
 
     # start Caterpillar
     start()

--- a/server.py
+++ b/server.py
@@ -7,7 +7,7 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2022-10-06
-# Updated at: 2024-07-04
+# Updated at: 2024-07-09
 #
 
 import argparse
@@ -499,7 +499,7 @@ def start():    #Main Program
 
 if __name__== "__main__":
     # load extensions
-    map(Extension.register, use_extension.split(',')))
+    map(Extension.register, use_extension.split(','))
 
     # start Caterpillar
     start()

--- a/web.py
+++ b/web.py
@@ -94,6 +94,6 @@ if __name__ == "__main__":
     Extension.set_protocol('http')
 
     # load extensions
-    map(Extension.register, use_extension.split(','))
+    map(Extension.register, use_extensions.split(','))
 
     app.run(debug=True, host='0.0.0.0', port=listening_port)

--- a/web.py
+++ b/web.py
@@ -94,6 +94,6 @@ if __name__ == "__main__":
     Extension.set_protocol('http')
 
     # load extensions
-    #Extension.register("plugins.YOUR_OWN_MODULE_NAME", "YOUR_OWN_CLASS_NAME");
+    map(Extension.register, use_extension.split(','))
 
     app.run(debug=True, host='0.0.0.0', port=listening_port)

--- a/web.py
+++ b/web.py
@@ -7,7 +7,7 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-05-20
-# Updated at: 2024-07-09
+# Updated at: 2024-07-10
 #
 
 from flask import Flask, request, redirect, url_for, render_template
@@ -94,6 +94,7 @@ if __name__ == "__main__":
     Extension.set_protocol('http')
 
     # load extensions
-    map(Extension.register, use_extensions.split(','))
+    for s in use_extensions.split(','):
+        Extension.register(s)
 
     app.run(debug=True, host='0.0.0.0', port=listening_port)

--- a/web.py
+++ b/web.py
@@ -7,7 +7,7 @@
 # Namyheon Go (Catswords Research) <gnh1201@gmail.com>
 # https://github.com/gnh1201/caterpillar
 # Created at: 2024-05-20
-# Updated at: 2024-07-06
+# Updated at: 2024-07-09
 #
 
 from flask import Flask, request, redirect, url_for, render_template


### PR DESCRIPTION
## 요약
* 기존: 코드에서 일일히 확장 등록
  ```py
  # load extensions
  Extension.register("plugins.fediverse", "Fediverse")
  Extension.register("plugins.container", "Container")
  Extension.register("plugins.wayback", "Wayback")
  Extension.register("plugins.bio", "PyBio")
  ```
* 변경: 코드에서는 간단하게 끝내고 설정파일(.env)에서 읽어서 확장 등록.

  - server.py 및 web.py 에서:
  ```py
  for s in use_extensions.split(','):
      Extension.register(s)
  ```
  
  - .env (또는 settings.ini) 에서:
  ```
  USE_EXTENSIONS=wayback.Wayback,bio.PyBio
  ```